### PR TITLE
Proguard/R8 Basic Support

### DIFF
--- a/cookie-store/build.gradle
+++ b/cookie-store/build.gradle
@@ -40,6 +40,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules.pro'
         }
     }
 

--- a/cookie-store/proguard-rules.pro
+++ b/cookie-store/proguard-rules.pro
@@ -15,3 +15,6 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Application class that will be serialized/deserialized over Gson
+-keep class java.net.HttpCookie { <fields>; }

--- a/example/app/proguard-rules.pro
+++ b/example/app/proguard-rules.pro
@@ -23,3 +23,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Class is serialized/deserialized over Gson by cookie-store dependency.
+-keep class java.net.HttpCookie { <fields>; }


### PR DESCRIPTION
Fixes issue #2  that happened when adding the `cookie-store` dependency to an app with Proguard/R8 enabled.

This PR adds a Proguard Rule to the `cookie-store` module to keep the `HttpCookie` class and prevent it from being minified and obfuscated, so it can be correctly serialized and deserialized by Gson.