### PR TITLE
feat: safe web kit cookie sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ val cookieManager = WebKitSyncCookieManager(
     cookiePolicy = CookiePolicy.ACCEPT_ALL,
     onWebKitCookieManagerError = { exception ->
         // This gets invoked when there's internal webkit cookie manager exceptions
-        Log.e("SYNC-FAIL", "WebKitCookieManagerError", exception)
+        Log.e("COOKIE-STORE", "WebKitSyncCookieManager error", exception)
     }
 )
 ```

--- a/README.md
+++ b/README.md
@@ -72,8 +72,12 @@ You have two ways of doing this:
 #### Using WebKitSyncCookieManager
 ```kotlin
 val cookieManager = WebKitSyncCookieManager(
-    createCookieStore(name = "myCookies", persistent = true),
-    CookiePolicy.ACCEPT_ALL
+    store = createCookieStore(name = "myCookies", persistent = true),
+    cookiePolicy = CookiePolicy.ACCEPT_ALL,
+    onWebKitCookieManagerError = { exception ->
+        // This gets invoked when there's internal webkit cookie manager exceptions
+        Log.e("SYNC-FAIL", "WebKitCookieManagerError", exception)
+    }
 )
 ```
 Then follow standard instructions from the Usage section to setup `HttpURLConnection` or `OkHttp` according to your needs.

--- a/cookie-store/src/main/java/net/gotev/cookiestore/CookieStoreExtensions.kt
+++ b/cookie-store/src/main/java/net/gotev/cookiestore/CookieStoreExtensions.kt
@@ -34,9 +34,7 @@ fun HttpCookie.toSetCookieString(): String {
 }
 
 @Synchronized
-fun CookieStore.syncToWebKitCookieManager() {
-    val webKitCookieManager = android.webkit.CookieManager.getInstance()
-
+fun CookieStore.syncToWebKitCookieManager(webKitCookieManager: android.webkit.CookieManager = android.webkit.CookieManager.getInstance()) {
     cookies.forEach {
         val hostUrl = "${if (it.secure) "https" else "http"}://${it.domain}"
         webKitCookieManager.setCookie(hostUrl, it.toSetCookieString())

--- a/cookie-store/src/main/java/net/gotev/cookiestore/CookieStoreExtensions.kt
+++ b/cookie-store/src/main/java/net/gotev/cookiestore/CookieStoreExtensions.kt
@@ -34,7 +34,9 @@ fun HttpCookie.toSetCookieString(): String {
 }
 
 @Synchronized
-fun CookieStore.syncToWebKitCookieManager(webKitCookieManager: android.webkit.CookieManager = android.webkit.CookieManager.getInstance()) {
+fun CookieStore.syncToWebKitCookieManager() {
+    val webKitCookieManager = android.webkit.CookieManager.getInstance()
+
     cookies.forEach {
         val hostUrl = "${if (it.secure) "https" else "http"}://${it.domain}"
         webKitCookieManager.setCookie(hostUrl, it.toSetCookieString())

--- a/cookie-store/src/main/java/net/gotev/cookiestore/WebKitSyncCookieManager.kt
+++ b/cookie-store/src/main/java/net/gotev/cookiestore/WebKitSyncCookieManager.kt
@@ -11,13 +11,9 @@ class WebKitSyncCookieManager(
     private val onWebKitCookieManagerError: ((Throwable) -> Unit)? = null
 ) : CookieManager(store, cookiePolicy) {
 
-    private val webKitCookieManager by lazy {
-        android.webkit.CookieManager.getInstance()
-    }
-
     init {
         try {
-            webKitCookieManager.setAcceptCookie(true)
+            android.webkit.CookieManager.getInstance().setAcceptCookie(true)
         } catch (exc: Throwable) {
             onWebKitCookieManagerError?.invoke(exc)
         }
@@ -26,7 +22,7 @@ class WebKitSyncCookieManager(
     override fun put(uri: URI?, responseHeaders: MutableMap<String, MutableList<String>>?) {
         super.put(uri, responseHeaders)
         try {
-            cookieStore.syncToWebKitCookieManager(webKitCookieManager)
+            cookieStore.syncToWebKitCookieManager()
         } catch (exc: Throwable) {
             onWebKitCookieManagerError?.invoke(exc)
         }
@@ -35,7 +31,7 @@ class WebKitSyncCookieManager(
     fun removeAll() {
         cookieStore.removeAll()
         try {
-            webKitCookieManager.removeAll()
+            android.webkit.CookieManager.getInstance().removeAll()
         } catch (exc: Throwable) {
             onWebKitCookieManagerError?.invoke(exc)
         }

--- a/example/app/src/main/java/net/gotev/cookiestoredemo/App.kt
+++ b/example/app/src/main/java/net/gotev/cookiestoredemo/App.kt
@@ -45,7 +45,7 @@ class App : Application() {
             cookiePolicy = CookiePolicy.ACCEPT_ALL,
             onWebKitCookieManagerError = { exception ->
                 // This gets invoked when there's internal webkit cookie manager exceptions
-                Log.e("SYNC-FAIL", "WebKitCookieManagerError", exception)
+                Log.e("COOKIE-STORE", "WebKitSyncCookieManager error", exception)
             }
         )
 

--- a/example/app/src/main/java/net/gotev/cookiestoredemo/App.kt
+++ b/example/app/src/main/java/net/gotev/cookiestoredemo/App.kt
@@ -1,6 +1,7 @@
 package net.gotev.cookiestoredemo
 
 import android.app.Application
+import android.util.Log
 import com.ashokvarma.gander.Gander
 import com.ashokvarma.gander.GanderInterceptor
 import com.ashokvarma.gander.imdb.GanderIMDB
@@ -40,8 +41,12 @@ class App : Application() {
         super.onCreate()
 
         cookieManager = WebKitSyncCookieManager(
-            createCookieStore(name = cookieStoreName, persistent = true),
-            CookiePolicy.ACCEPT_ALL
+            store = createCookieStore(name = cookieStoreName, persistent = true),
+            cookiePolicy = CookiePolicy.ACCEPT_ALL,
+            onWebKitCookieManagerError = { exception ->
+                // This gets invoked when there's internal webkit cookie manager exceptions
+                Log.e("SYNC-FAIL", "WebKitCookieManagerError", exception)
+            }
         )
 
         // Setup for HttpURLConnection

--- a/example/app/src/main/java/net/gotev/cookiestoredemo/MainActivity.kt
+++ b/example/app/src/main/java/net/gotev/cookiestoredemo/MainActivity.kt
@@ -56,9 +56,14 @@ class MainActivity : AppCompatActivity() {
 
         webView.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
-                val cookie = android.webkit.CookieManager.getInstance().getCookie(url)
-                Log.e("COOKIE", "For url $url: [$cookie]")
-                toast("Cookie for url $url: [$cookie]")
+                try {
+                    val cookie = android.webkit.CookieManager.getInstance().getCookie(url)
+                    Log.e("COOKIE", "For url $url: [$cookie]")
+                    toast("Cookie for url $url: [$cookie]")
+                } catch (exc: Throwable) {
+                    Log.e("COOKIE-MANAGER", "Android WebKitCookieManager error", exc)
+                    toast("$exc")
+                }
             }
         }
 


### PR DESCRIPTION
As reported in #17 there are devices on which com.google.android.webview is not found. To prevent crashes, the `WebKitSyncCookieManager` has been upgraded to catch exceptions and delegate them to an optional lambda. By default the lambda is null and if an exception happens, a log will be written. If the lambda is defined, the exception will be injected to it, allowing the library user to do something when that error happens.