### PR TITLE
Fix Android 12 serialization

### DIFF
--- a/cookie-store-okhttp/build.gradle
+++ b/cookie-store-okhttp/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 
     // Kotlin
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.squareup.okhttp3:okhttp:4.9.2"
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
 
 test {

--- a/cookie-store/build.gradle
+++ b/cookie-store/build.gradle
@@ -67,8 +67,8 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidx_test_espresso_version"
 
     // Kotlin
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.google.code.gson:gson:2.8.9"
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "com.google.code.gson:gson:2.9.0"
 }
 
 apply from: 'https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/master/gradle-mavenizer.gradle'

--- a/cookie-store/src/main/java/net/gotev/cookiestore/InMemoryCookieStore.kt
+++ b/cookie-store/src/main/java/net/gotev/cookiestore/InMemoryCookieStore.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.locks.ReentrantLock
 // Kotlin-ized starting from https://chromium.googlesource.com/android_tools/+/master/sdk/sources/android-25/java/net/InMemoryCookieStore.java
 open class InMemoryCookieStore(private val name: String) : CookieStore {
 
-    internal val uriIndex = LinkedHashMap<URI, ArrayList<HttpCookie>>()
+    internal val uriIndex = LinkedHashMap<URI, MutableList<HttpCookie>>()
     private val lock = ReentrantLock(false)
 
     override fun removeAll(): Boolean {

--- a/cookie-store/src/main/java/net/gotev/cookiestore/InternalCookie.kt
+++ b/cookie-store/src/main/java/net/gotev/cookiestore/InternalCookie.kt
@@ -1,0 +1,49 @@
+package net.gotev.cookiestore
+
+import android.os.Build
+import java.net.HttpCookie
+
+data class InternalCookie(
+    val comment: String?,
+    val commentURL: String?,
+    val discard: Boolean?,
+    val domain: String,
+    val maxAge: Long?,
+    val name: String,
+    val path: String?,
+    val portlist: String?,
+    val secure: Boolean?,
+    val value: String,
+    val version: Int?,
+    var httpOnly: Boolean? = null
+) {
+    constructor(cookie: HttpCookie) : this(
+        cookie.comment,
+        cookie.commentURL,
+        cookie.discard,
+        cookie.domain,
+        cookie.maxAge,
+        cookie.name,
+        cookie.path,
+        cookie.portlist,
+        cookie.secure,
+        cookie.value,
+        cookie.version
+    )
+
+    fun toHttpCookie() = HttpCookie(name, value).apply {
+        comment = this@InternalCookie.comment
+        commentURL = this@InternalCookie.commentURL
+        discard = this@InternalCookie.discard == true
+        domain = this@InternalCookie.domain
+        maxAge = this@InternalCookie.maxAge ?: 0
+        path = this@InternalCookie.path
+        portlist = this@InternalCookie.portlist
+        secure = this@InternalCookie.secure == true
+        version = this@InternalCookie.version ?: 0
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            isHttpOnly = this@InternalCookie.httpOnly == true
+        }
+    }
+}

--- a/example/app/build.gradle
+++ b/example/app/build.gradle
@@ -53,12 +53,12 @@ dependencies {
 
     // Support
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.5.0'
 
     implementation project(':cookie-store')
     implementation project(':cookie-store-okhttp')
 
-    def okHttpVersion = "4.9.1"
+    def okHttpVersion = "4.9.3"
     implementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
 
     def retrofitVersion = "2.9.0"
@@ -66,7 +66,7 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
 }
 
 task prepareKotlinBuildScriptModel {}

--- a/manifest.gradle
+++ b/manifest.gradle
@@ -16,19 +16,19 @@ ext {
     demo_app_id = 'net.gotev.cookiestoredemo'
 
     // Gradle classpath dependencies versions
-    kotlin_version = '1.4.32'
+    kotlin_version = '1.6.10'
     gradle_version = '7.0.3'
     kotlin_lint_version = '9.0.0'
 
     // Library and app testing dependencies versions
-    junit_version = '4.13'
-    androidx_test_core_version = '1.3.0'
-    androidx_test_runner_version = '1.3.0'
-    androidx_test_rules_version = '1.3.0'
-    androidx_test_ext_junit_version = '1.1.2'
-    androidx_test_ext_truth_version = '1.3.0'
+    junit_version = '4.13/2'
+    androidx_test_core_version = '1.4.0'
+    androidx_test_runner_version = '1.4.0'
+    androidx_test_rules_version = '1.4.0'
+    androidx_test_ext_junit_version = '1.1.3'
+    androidx_test_ext_truth_version = '1.4.0'
     truth_version = '1.0.1'
-    androidx_test_espresso_version = '3.3.0'
+    androidx_test_espresso_version = '3.4.0'
 
     // Library and app dependencies versions
     androidx_appcompat_version = '1.1.0'


### PR DESCRIPTION
- Use a custom `InternalCookie` type to avoid serialisation issues for `HttpCookie` on Android 12+

Related https://github.com/gotev/android-cookie-store/issues/28
Related https://github.com/appwrite/sdk-for-android/issues/20