### PR TITLE
fixed default accepting cookie in cookie store

### DIFF
--- a/cookie-store/src/main/java/net/gotev/cookiestore/WebKitSyncCookieManager.kt
+++ b/cookie-store/src/main/java/net/gotev/cookiestore/WebKitSyncCookieManager.kt
@@ -27,12 +27,6 @@ class WebKitSyncCookieManager(
         }
     }
 
-    init {
-        handleExceptions {
-            android.webkit.CookieManager.getInstance().setAcceptCookie(true)
-        }
-    }
-
     override fun put(uri: URI?, responseHeaders: MutableMap<String, MutableList<String>>?) {
         super.put(uri, responseHeaders)
         handleExceptions {

--- a/manifest.gradle
+++ b/manifest.gradle
@@ -9,7 +9,7 @@ ext {
     library_licenses = ["Apache-2.0"]
     library_licenses_url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
     library_project_group = 'net.gotev'
-    library_version = '1.5.0'
+    library_version = '1.6.0'
     version_code = 3
     min_sdk = 16
     target_sdk = 31


### PR DESCRIPTION
    init {
        handleExceptions {
            android.webkit.CookieManager.getInstance().setAcceptCookie(true)
        }
    }

The default value of setAcceptCookie is true. removing it since cookiemanager instance creates ANR in few devices

issue discussion thread https://github.com/gotev/android-cookie-store/issues/38#issue-2284878355